### PR TITLE
⚡ 로컬에 json 형태로 저장하도록 MyFileManager를 리팩토링하고, 메소드 인자에 폴더를 구분하여 저장하도록 변경합니다.

### DIFF
--- a/RaniPaper.xcodeproj/project.pbxproj
+++ b/RaniPaper.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		7B796F7D2936DABC00799616 /* MyFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B796F7C2936DABC00799616 /* MyFileManager.swift */; };
 		7B796F8529378CB300799616 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B796F8429378CB300799616 /* HomeView.swift */; };
 		7B796F8729378CD500799616 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B796F8629378CD500799616 /* HomeViewModel.swift */; };
+		7B796F8929384FEA00799616 /* MemoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B796F8829384FEA00799616 /* MemoModel.swift */; };
 		D86ACE1D292DDF1F002C8E89 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86ACE1C292DDF1F002C8E89 /* MainViewModel.swift */; };
 		D86ACE20292DE0E0002C8E89 /* LaunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86ACE1F292DE0E0002C8E89 /* LaunchView.swift */; };
 		D86ACE24292DE28E002C8E89 /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86ACE23292DE28E002C8E89 /* Extension.swift */; };
@@ -67,6 +68,7 @@
 		7B796F7C2936DABC00799616 /* MyFileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyFileManager.swift; sourceTree = "<group>"; };
 		7B796F8429378CB300799616 /* HomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		7B796F8629378CD500799616 /* HomeViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
+		7B796F8829384FEA00799616 /* MemoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoModel.swift; sourceTree = "<group>"; };
 		D86ACE1C292DDF1F002C8E89 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		D86ACE1F292DE0E0002C8E89 /* LaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchView.swift; sourceTree = "<group>"; };
 		D86ACE23292DE28E002C8E89 /* Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extension.swift; sourceTree = "<group>"; };
@@ -138,6 +140,7 @@
 				493526FD292FFC030066F083 /* MenuModel.swift */,
 				D86ACE5E29347D0B002C8E89 /* DateModel.swift */,
 				D86ACE6029349E78002C8E89 /* TaskModel.swift */,
+				7B796F8829384FEA00799616 /* MemoModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -459,6 +462,7 @@
 				D8D549C2293611CB001E4287 /* EditTaskViewModel.swift in Sources */,
 				D86ACE31292DFCAD002C8E89 /* LockViewModel.swift in Sources */,
 				D86ACE34292F0A3E002C8E89 /* ConfirmView.swift in Sources */,
+				7B796F8929384FEA00799616 /* MemoModel.swift in Sources */,
 				D86ACE2F292DF6E2002C8E89 /* Enum.swift in Sources */,
 				493526F5292F57470066F083 /* MenuViewModel.swift in Sources */,
 				7B796F8529378CB300799616 /* HomeView.swift in Sources */,

--- a/RaniPaper/Source/Model/MemoModel.swift
+++ b/RaniPaper/Source/Model/MemoModel.swift
@@ -1,0 +1,15 @@
+//
+//  MemoModel.swift
+//  RaniPaper
+//
+//  Created by YoungK on 2022/12/01.
+//
+
+import Foundation
+
+struct MemoModel: Identifiable, Codable {
+    var id = UUID().uuidString
+    var date: Date = Date()
+    var title:String
+    var content: String
+}

--- a/RaniPaper/Source/View/HomeView/HomeView.swift
+++ b/RaniPaper/Source/View/HomeView/HomeView.swift
@@ -25,6 +25,8 @@ struct HomeView: View {
                     
                 }
             
+            fileManagerTestButtonView() // 테스트용입니다.
+            
             if isAnimating {
                 LottieView(name: "mail-boxletter-box", loopMode: .playOnce)
                     .background(Color.black.opacity(0.6))
@@ -44,5 +46,59 @@ struct HomeView: View {
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
         HomeView()
+    }
+}
+
+extension HomeView {
+    func fileManagerTestButtonView() -> some View {
+        VStack {
+            Button {
+                let result = MyFileManager.shared.create(at: .memo, fileName: "memo01.json", MemoModel(title: "테스트용 메모제목", content: "테스트용 내용입니다."))
+                switch result {
+                case .success():
+                    print("success")
+                case .failure(let failure):
+                    print(failure.errorDescription)
+                }
+            } label: {
+                Text("CREATE").padding().background(RoundedRectangle(cornerRadius: 8).foregroundColor(.gray))
+            }
+            
+            Button {
+                let result = MyFileManager.shared.read(at: .memo, fileName: "memo01.json")
+                switch result {
+                case .success(let jsonData):
+                    print(jsonData)
+                case .failure(let failure):
+                    print(failure.errorDescription)
+                }
+            } label: {
+                Text("READ").padding().background(RoundedRectangle(cornerRadius: 8).foregroundColor(.gray))
+            }
+            
+            Button {
+                let result = MyFileManager.shared.update(at: .memo, fileName: "memo01.json", MemoModel(title: "테스트용 메모제목2222", content: "테스트용 내용입니다.2222"))
+                switch result {
+                case .success():
+                    print("success")
+                case .failure(let failure):
+                    print(failure.errorDescription)
+                }
+            } label: {
+                Text("UPDATE").padding().background(RoundedRectangle(cornerRadius: 8).foregroundColor(.gray))
+            }
+            
+            Button {
+                let result = MyFileManager.shared.delete(at: .memo, fileName: "memo01.json")
+                switch result {
+                case .success():
+                    print("success")
+                case .failure(let failure):
+                    print(failure.errorDescription)
+                }
+            } label: {
+                Text("DELETE").padding().background(RoundedRectangle(cornerRadius: 8).foregroundColor(.gray))
+            }
+        }
     }
 }


### PR DESCRIPTION
### 배경
- Memo, Diary 두가지 모델을 저장해야 했습니다.

### 작업 내용
- **MemoModel**을 추가합니다.
- Documents/RaniPaper/Memo, Documents/RaniPaper/Diary **두개의 폴더가 생성되도록 변경**하였습니다.
- CRUD 메소드 인자에 **folder 를 설정하여 저장될 위치를 선택**하도록 하였습니다.
- MyFileManager의 남아 있던 **do catch 문을 모두 제거**했습니다.
- **CRUD를 테스트**해볼 수 있도록 홈뷰에 fileManagerTestButtonView() -> some View 를 만들어뒀습니다.