### PR TITLE
⚡ 유저의 상태를 저장할 UserState를 만들어 최초 선택 후, 바로 HomeView로 진입하도록 합니다.

### DIFF
--- a/RaniPaper.xcodeproj/project.pbxproj
+++ b/RaniPaper.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		7B796F90293A22FA00799616 /* MailBoxAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B796F8F293A22FA00799616 /* MailBoxAnimationView.swift */; };
 		7B796F92293A462A00799616 /* RollingPaperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B796F91293A462A00799616 /* RollingPaperView.swift */; };
 		7B796F94293D74BB00799616 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B796F93293D74BB00799616 /* HapticManager.swift */; };
+		7B796F96293E312000799616 /* UserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B796F95293E312000799616 /* UserState.swift */; };
 		D86ACE1D292DDF1F002C8E89 /* MainViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86ACE1C292DDF1F002C8E89 /* MainViewModel.swift */; };
 		D86ACE20292DE0E0002C8E89 /* LaunchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86ACE1F292DE0E0002C8E89 /* LaunchView.swift */; };
 		D86ACE24292DE28E002C8E89 /* Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D86ACE23292DE28E002C8E89 /* Extension.swift */; };
@@ -101,6 +102,7 @@
 		7B796F8F293A22FA00799616 /* MailBoxAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailBoxAnimationView.swift; sourceTree = "<group>"; };
 		7B796F91293A462A00799616 /* RollingPaperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingPaperView.swift; sourceTree = "<group>"; };
 		7B796F93293D74BB00799616 /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
+		7B796F95293E312000799616 /* UserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserState.swift; sourceTree = "<group>"; };
 		D86ACE1C292DDF1F002C8E89 /* MainViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewModel.swift; sourceTree = "<group>"; };
 		D86ACE1F292DE0E0002C8E89 /* LaunchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchView.swift; sourceTree = "<group>"; };
 		D86ACE23292DE28E002C8E89 /* Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extension.swift; sourceTree = "<group>"; };
@@ -253,6 +255,7 @@
 		D86ACE18292DDD93002C8E89 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				7B796F95293E312000799616 /* UserState.swift */,
 				7B796F7B2936DAA300799616 /* Utils */,
 				493526FB292FFBE30066F083 /* Model */,
 				D86ACE22292DE272002C8E89 /* Extension */,
@@ -583,6 +586,7 @@
 				D8D549C02934FB06001E4287 /* EditTaskView.swift in Sources */,
 				7B796F92293A462A00799616 /* RollingPaperView.swift in Sources */,
 				D86ACE20292DE0E0002C8E89 /* LaunchView.swift in Sources */,
+				7B796F96293E312000799616 /* UserState.swift in Sources */,
 				D8FF9358293A57A700B0F475 /* SmallStickerView.swift in Sources */,
 				D8FF935D293A586800B0F475 /* MemoViewModel.swift in Sources */,
 				D89A06932929FD5000F5D408 /* RaniPaperApp.swift in Sources */,

--- a/RaniPaper/RaniPaperApp.swift
+++ b/RaniPaper/RaniPaperApp.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct RaniPaperApp: App {
     var body: some Scene {
         WindowGroup {
-            MainView()
+            MainView().environmentObject(UserState.shared)
         }
     }
 }

--- a/RaniPaper/Resource/Constants/Enum.swift
+++ b/RaniPaper/Resource/Constants/Enum.swift
@@ -8,10 +8,10 @@
 import Foundation
 import SwiftUI
 
-enum UserType {
-    case none
-    case viichan
-    case fan
+enum UserType: String {
+    case none = "none"
+    case viichan = "viichan"
+    case fan = "fan"
 }
 
 enum ScreenSize {

--- a/RaniPaper/Resource/Constants/Enum.swift
+++ b/RaniPaper/Resource/Constants/Enum.swift
@@ -8,10 +8,10 @@
 import Foundation
 import SwiftUI
 
-enum LockState{
-    case locked
+enum UserType {
+    case none
     case viichan
-    case rani
+    case fan
 }
 
 enum ScreenSize {

--- a/RaniPaper/Source/UserState.swift
+++ b/RaniPaper/Source/UserState.swift
@@ -1,0 +1,46 @@
+//
+//  UserState.swift
+//  RaniPaper
+//
+//  Created by YoungK on 2022/12/05.
+//
+
+import Foundation
+
+class UserState: ObservableObject {
+    static let shared = UserState()
+    
+    @Published var userType: UserType
+    
+    init() {
+        print("✅ UserState 생성")
+        self.userType = .none
+        fetch()
+    }
+    
+    func fetch() {
+        guard let userTypeString: String = UserDefaults.standard.object(forKey: "userType") as? String else { return }
+        print("userType 을 불러왔습니다: \(userTypeString)")
+        
+        switch userTypeString {
+        case "none":
+            self.userType = .none
+            
+        case "fan":
+            self.userType = .fan
+            
+        case "viichan":
+            self.userType = .viichan
+            
+        default:
+            self.userType = .none
+        }
+        
+    }
+    
+    func update(_ userType: UserType) {
+        print("userType 을 저장합니다: \(userType)")
+        UserDefaults.standard.set(userType.rawValue, forKey: "userType")
+        fetch()
+    }
+}

--- a/RaniPaper/Source/View/ConfirmView/ConfirmView.swift
+++ b/RaniPaper/Source/View/ConfirmView/ConfirmView.swift
@@ -10,9 +10,9 @@ import PopupView
 
 
 struct ConfirmView: View {
-    @Binding var lockState:LockState
-    @State var showLockView:Bool = false
-    let textSize:CGFloat = 27
+    @Binding var userType: UserType
+    @State var showLockView: Bool = false
+    let textSize: CGFloat = 27
     
     var body: some View {
         ZStack{
@@ -41,7 +41,7 @@ struct ConfirmView: View {
                         Button {
                             DispatchQueue.main.asyncAfter(deadline: .now()+0.3) {
                                 withAnimation {
-                                    lockState = .rani
+                                    userType = .fan
                                 }
                             }
                         } label: {
@@ -59,7 +59,7 @@ struct ConfirmView: View {
             }
         }.popup(isPresented: $showLockView,closeOnTap: false,closeOnTapOutside: true,backgroundColor: .black.opacity(0.2)) {
             
-            LockView(lockState: $lockState,showLockView:$showLockView)
+            LockView(userType: $userType,showLockView:$showLockView)
         }
         .edgesIgnoringSafeArea(.vertical)
     
@@ -69,7 +69,7 @@ struct ConfirmView: View {
 
 struct ConfirmView_Previews: PreviewProvider {
     static var previews: some View {
-        ConfirmView(lockState: .constant(.locked))
+        ConfirmView(userType: .constant(.none))
     }
 }
 

--- a/RaniPaper/Source/View/ConfirmView/ConfirmView.swift
+++ b/RaniPaper/Source/View/ConfirmView/ConfirmView.swift
@@ -10,7 +10,7 @@ import PopupView
 
 
 struct ConfirmView: View {
-    @Binding var userType: UserType
+    @EnvironmentObject var userState: UserState
     @State var showLockView: Bool = false
     let textSize: CGFloat = 27
     
@@ -41,7 +41,7 @@ struct ConfirmView: View {
                         Button {
                             DispatchQueue.main.asyncAfter(deadline: .now()+0.3) {
                                 withAnimation {
-                                    userType = .fan
+                                    userState.update(.fan)
                                 }
                             }
                         } label: {
@@ -59,7 +59,7 @@ struct ConfirmView: View {
             }
         }.popup(isPresented: $showLockView,closeOnTap: false,closeOnTapOutside: true,backgroundColor: .black.opacity(0.2)) {
             
-            LockView(userType: $userType,showLockView:$showLockView)
+            LockView(showLockView:$showLockView).environmentObject(userState)
         }
         .edgesIgnoringSafeArea(.vertical)
     
@@ -69,7 +69,7 @@ struct ConfirmView: View {
 
 struct ConfirmView_Previews: PreviewProvider {
     static var previews: some View {
-        ConfirmView(userType: .constant(.none))
+        ConfirmView().environmentObject(UserState.shared)
     }
 }
 

--- a/RaniPaper/Source/View/HomeView/HomeView.swift
+++ b/RaniPaper/Source/View/HomeView/HomeView.swift
@@ -34,20 +34,7 @@ struct HomeView: View {
                     })
                 
                 // MARK: 테스트용 뷰
-                VStack {
-                    Spacer()
-                    
-                    if userState.userType == .viichan {
-                        Text("계정상태: viiChan")
-                    } else { if userState.userType == .fan {
-                        Text("계정상태: fan")
-                    } else {
-                        Text("계정상태: none")
-                    } }
-                    
-                    soundSettingTestButtonView()
-                    Spacer().frame(height: 50)
-                }
+                TestView()
                 
             }
             .ignoresSafeArea()
@@ -64,6 +51,29 @@ struct HomeView_Previews: PreviewProvider {
 }
 
 extension HomeView {
+    func TestView() -> some View {
+        VStack {
+            Spacer()
+            
+            if userState.userType == .viichan {
+                Text("계정상태: viiChan")
+            } else { if userState.userType == .fan {
+                Text("계정상태: fan")
+            } else {
+                Text("계정상태: none")
+            } }
+            Button {
+                withAnimation { userState.update(.none) }
+            } label: {
+                Text("뒤로가기").foregroundColor(.red)
+            }
+
+            
+            soundSettingTestButtonView()
+            Spacer().frame(height: 50)
+        }
+    }
+    
     func fileManagerTestButtonView() -> some View {
         VStack {
             Button {

--- a/RaniPaper/Source/View/HomeView/HomeView.swift
+++ b/RaniPaper/Source/View/HomeView/HomeView.swift
@@ -10,6 +10,7 @@ import UIKit
 import Lottie
 
 struct HomeView: View {
+    @EnvironmentObject var userState: UserState
     @StateObject var viewModel = HomeViewModel()
     @State var isAnimating = false
     
@@ -31,7 +32,23 @@ struct HomeView: View {
                                 .contentShape(Rectangle())
                         }
                     })
-                soundSettingTestButtonView()
+                
+                // MARK: 테스트용 뷰
+                VStack {
+                    Spacer()
+                    
+                    if userState.userType == .viichan {
+                        Text("계정상태: viiChan")
+                    } else { if userState.userType == .fan {
+                        Text("계정상태: fan")
+                    } else {
+                        Text("계정상태: none")
+                    } }
+                    
+                    soundSettingTestButtonView()
+                    Spacer().frame(height: 50)
+                }
+                
             }
             .ignoresSafeArea()
         }
@@ -42,7 +59,7 @@ struct HomeView: View {
 
 struct HomeView_Previews: PreviewProvider {
     static var previews: some View {
-        HomeView()
+        HomeView().environmentObject(UserState.shared)
     }
 }
 

--- a/RaniPaper/Source/View/HomeView/MailBoxAnimationView.swift
+++ b/RaniPaper/Source/View/HomeView/MailBoxAnimationView.swift
@@ -27,7 +27,6 @@ struct MailBoxAnimationView: View {
                 if isAnimating { // 애니메이션 시작
                     
                     LottieView(name: "mail-boxletter-box", speed: 0.7) {
-                        //애니메이션이 너무 빨리 끝나서 0.5초 딜레이
                         isAnimating = false
                         
                         //남은 롤링페이퍼가 있을 경우에만 보여줌

--- a/RaniPaper/Source/View/LockView/LockView.swift
+++ b/RaniPaper/Source/View/LockView/LockView.swift
@@ -9,8 +9,8 @@ import SwiftUI
 import Combine
 
 struct LockView: View {
-    @Binding var lockState:LockState
-    @Binding var showLockView:Bool
+    @Binding var userType: UserType
+    @Binding var showLockView: Bool
     @StateObject var viewModel = LockViewModel()
     let gangfont:Font = Font.gangwonBold(20)
     fileprivate let bgGradient = Color(hexcode: "e7f4ea")
@@ -61,7 +61,7 @@ struct LockView: View {
                     showLockView = false
                     DispatchQueue.main.asyncAfter(deadline: .now()+0.3) {
                         withAnimation {
-                            lockState = .viichan
+                            userType = .viichan
                         }
                     }
                 }
@@ -98,6 +98,6 @@ struct LockView: View {
 
 struct LockView_Previews: PreviewProvider {
     static var previews: some View {
-        LockView(lockState: .constant(.locked),showLockView: .constant(false))
+        LockView(userType: .constant(.none),showLockView: .constant(false))
     }
 }

--- a/RaniPaper/Source/View/LockView/LockView.swift
+++ b/RaniPaper/Source/View/LockView/LockView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import Combine
 
 struct LockView: View {
-    @Binding var userType: UserType
+    @EnvironmentObject var userState: UserState
     @Binding var showLockView: Bool
     @StateObject var viewModel = LockViewModel()
     let gangfont:Font = Font.gangwonBold(20)
@@ -61,7 +61,7 @@ struct LockView: View {
                     showLockView = false
                     DispatchQueue.main.asyncAfter(deadline: .now()+0.3) {
                         withAnimation {
-                            userType = .viichan
+                            userState.update(.viichan)
                         }
                     }
                 }
@@ -98,6 +98,6 @@ struct LockView: View {
 
 struct LockView_Previews: PreviewProvider {
     static var previews: some View {
-        LockView(userType: .constant(.none),showLockView: .constant(false))
+        LockView(showLockView: .constant(false)).environmentObject(UserState.shared)
     }
 }

--- a/RaniPaper/Source/View/MainView/MainView.swift
+++ b/RaniPaper/Source/View/MainView/MainView.swift
@@ -9,12 +9,13 @@ import SwiftUI
 
 
 struct MainView: View {
+    @EnvironmentObject var userState: UserState
     @StateObject var viewModel = MainViewModel()
     
     var body: some View {
         
-        if viewModel.userType == .none {
-            ConfirmView(userType: $viewModel.userType)
+        if userState.userType == .none {
+            ConfirmView().environmentObject(userState)
 
         }
         else{
@@ -60,7 +61,7 @@ struct MainView: View {
                         }
                     }
                     MenuView(selection: $viewModel.selection)
-                }
+                }.environmentObject(UserState.shared)
             }
         }
     }
@@ -68,6 +69,6 @@ struct MainView: View {
 
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
-        MainView()
+        MainView().environmentObject(UserState.shared)
     }
 }

--- a/RaniPaper/Source/View/MainView/MainView.swift
+++ b/RaniPaper/Source/View/MainView/MainView.swift
@@ -13,8 +13,8 @@ struct MainView: View {
     
     var body: some View {
         
-        if viewModel.lockState == .locked {
-            ConfirmView(lockState: $viewModel.lockState)
+        if viewModel.userType == .none {
+            ConfirmView(userType: $viewModel.userType)
 
         }
         else{

--- a/RaniPaper/Source/View/SettingView/SettingView.swift
+++ b/RaniPaper/Source/View/SettingView/SettingView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct SettingView: View {
+    @EnvironmentObject var userState: UserState
     @ObservedObject var viewModel = SettingViewModel()
     var body: some View {
         ZStack{
@@ -24,6 +25,13 @@ struct SettingView: View {
                     }
                     .background(Color.clear)
                     .listRowBackground(Color.clear)
+                    
+                    Button(action: {
+                        withAnimation {
+                            userState.update(.none)
+                        }
+                    }, label: { Text("로그아웃").foregroundColor(.red) })
+                    
                 }
                 .listStyle(.plain)
                 .padding(.horizontal, 20)
@@ -36,6 +44,6 @@ struct SettingView: View {
 
 struct SettingView_Previews: PreviewProvider {
     static var previews: some View {
-        SettingView()
+        SettingView().environmentObject(UserState.shared)
     }
 }

--- a/RaniPaper/Source/View/SettingView/SettingView.swift
+++ b/RaniPaper/Source/View/SettingView/SettingView.swift
@@ -26,12 +26,6 @@ struct SettingView: View {
                     .background(Color.clear)
                     .listRowBackground(Color.clear)
                     
-                    Button(action: {
-                        withAnimation {
-                            userState.update(.none)
-                        }
-                    }, label: { Text("로그아웃").foregroundColor(.red) })
-                    
                 }
                 .listStyle(.plain)
                 .padding(.horizontal, 20)

--- a/RaniPaper/Source/ViewModel/MainViewModel.swift
+++ b/RaniPaper/Source/ViewModel/MainViewModel.swift
@@ -10,13 +10,11 @@ import Combine
 import SwiftUI
 
 final class MainViewModel : ObservableObject {
-    @Published var isLoading:Bool
-    @Published var lockState:LockState
+    @Published var isLoading: Bool
     @Published var selection: ViewSelection
 
     init(){
         self.isLoading = true
-        self.lockState = .locked
         self.selection = .home
         
         print("✅ MainViewModel 생성")


### PR DESCRIPTION
### 배경
- "비챤", "이파리" 선택 화면에서 최초 선택한 다음부턴 바로 런치스크린, 홈뷰로 진입되도록 구현해야 했습니다.
- 유저의 상태에 따라 기능을 Disable/ Enable 할 수 있도록 해야 했습니다.

### 작업 내용
- 원하는 뷰에서 유저의 상태에 따라 분기 처리할 수 있도록 하기 위해, MainViewModel 에 종속되지 않고 글로벌하게 접근할 수있도록,
UserState 클래스를 **싱글톤**으로 선언하여 **main 엔트리 포인트에서 최초 생성 후** **EnvironmentObject** 로 각 뷰에게 전달합니다.
- 유저디폴트를 통해 유저의 상태를 저장하고 불러오는 update(), fetch() 메소드를 추가합니다.
-  MainViewModel 에서 사용중이던 LockState 를 UserType 으로 변경합니다.


### 참고 영상
- 최초 '이파리' 선택 후 앱 재실행 시 바로 런치스크린 - 홈뷰로 이동하는 모습

https://user-images.githubusercontent.com/60254939/205677523-70d4e3ed-c646-444a-b4c5-c448a86d1470.mov

