### PR TITLE
⚡ 일부 기종에서 DatePicker 의 레이아웃이 깨지는 문제를 해결합니다.

### DIFF
--- a/RaniPaper/Source/View/CalendarView/EditTaskView.swift
+++ b/RaniPaper/Source/View/CalendarView/EditTaskView.swift
@@ -86,28 +86,20 @@ struct EditTaskView: View {
                                     .font(.caption)
                                     .foregroundColor(.gray)
                                 
-                                Text(viewModel.taskDeadLine.formatted(date: .numeric, time: .shortened))
-                                    .font(.callout)
-                                    .fontWeight(.semibold)
-                                    .padding(.top,8)
-                                    .onTapGesture {
-                                        UIApplication.shared.endEditing()
-                                        viewModel.showDatePicker = true
-                                    }
-                                
-                                
-                            }
-                            .frame(maxWidth: .infinity,alignment: .leading)
-                            .overlay(alignment:.bottomTrailing) {
-                                Button {
-                                    UIApplication.shared.endEditing()
-                                    viewModel.showDatePicker.toggle()
-                                } label: {
-                                    Image(systemName: "calendar")
-                                        .foregroundColor(.black)
+                                HStack {
+                                    DatePicker.init("", selection: $viewModel.taskDeadLine,
+                                                    in:Date.now...Date.distantFuture,
+                                                    displayedComponents: [.date, .hourAndMinute]
+                                    )
+                                    .datePickerStyle(.automatic)
+                                    .labelsHidden()
+                                    
+                                    Spacer()
+                                    
+                                    Image(systemName: "calendar").foregroundColor(.black)
                                 }
-                                
                             }
+                                
                             Divider()
                                 .padding(.vertical,10)
                             
@@ -210,51 +202,6 @@ struct EditTaskView: View {
             }
             
             
-        }
-        .overlay { //가장 바깥에 두어 전부다 Blur뷰로 덮기위해
-            ZStack{
-                if viewModel.showDatePicker{
-                    Rectangle()
-                        .fill(.ultraThinMaterial)
-                        .ignoresSafeArea()
-                        .onTapGesture {
-                            viewModel.showDatePicker = false
-                        }
-                    
-                    
-                    // MARK: DataPicker
-                    //현재부터 미래 까지
-                    //데이터 피커와 viewModel 데드라인 연결
-                    VStack(spacing: 5) {
-                        DatePicker.init("", selection: $viewModel.taskDeadLine,
-                                        in:Date.now...Date.distantFuture)
-                        .datePickerStyle(.graphical) //달력과 시간을 그래픽컬하게
-                        .labelsHidden()
-                        .background(.white,in: RoundedRectangle(cornerRadius: 12,style: .continuous))
-                        .padding(30) //시간 선택창 짤림화면 방지 패딩
-                        /* Button {
-                         viewModel.showDatePicker = false
-                         } label: {
-                         Text("날짜 저장하기")
-                         .font(.callout)
-                         .fontWeight(.semibold)
-                         
-                         .padding(15)
-                         .foregroundColor(.white)
-                         .background {
-                         Capsule()
-                         .fill(.blue)
-                         
-                         
-                         }
-                         }*/
-                    }
-                    
-                    
-                    
-                }
-            }
-            .animation(.easeInOut, value: viewModel.showDatePicker)
         }
         .onAppear {
             print("EditTaskview - onAppear")

--- a/RaniPaper/Source/ViewModel/EditTaskViewModel.swift
+++ b/RaniPaper/Source/ViewModel/EditTaskViewModel.swift
@@ -14,7 +14,6 @@ final class EditTaskViewModel:ObservableObject{
     @Published var taskDeadLine:Date = Date()
     @Published var taskColor:String = "ine"
     @Published var taskTicket:String = "우왁굳"
-    @Published var showDatePicker:Bool = false
     @Published private(set) var keyboardHeight: CGFloat = 0
     
     


### PR DESCRIPTION
### 배경
- #18 
(iOS 16 기준) 아이폰 14 Pro, 아이폰 14 Pro Max 에서 DatePicker 를 graphical 옵션으로 띄울 시 레이아웃이 깨지는걸 확인할 수 있었습니다.

https://user-images.githubusercontent.com/60254939/206066898-c9a82aa8-700f-4b45-8ead-edc2e4cf6b47.mov

### 작업 내용
- 문제가 되던 graphical 옵션을 automaic 으로 변경하였습니다.
- 기존에 graphical DatePicker를 띄우기 위한 캘린더 이미지 버튼은 버튼 기능을 제거하였습니다.

https://user-images.githubusercontent.com/60254939/206066631-ef58a13d-20cf-4fa0-a292-1b945348acfd.mov