### PR TITLE
⚡ 앱이 foreground/background 상태에서 푸시 알림을 탭하면 다이어리뷰로 이동하도록 합니다

### DIFF
--- a/RaniPaper.xcodeproj/project.pbxproj
+++ b/RaniPaper.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		494967C72940EAC8001E5E8A /* openSideMenu.wav in Resources */ = {isa = PBXBuildFile; fileRef = 494967C62940EAC8001E5E8A /* openSideMenu.wav */; };
 		49762B7E294151C300D3DD18 /* closeSideMenu.wav in Resources */ = {isa = PBXBuildFile; fileRef = 49762B7D294151C300D3DD18 /* closeSideMenu.wav */; };
 		49762B80294151DB00D3DD18 /* BGM.wav in Resources */ = {isa = PBXBuildFile; fileRef = 49762B7F294151DB00D3DD18 /* BGM.wav */; };
+		49762B822941595C00D3DD18 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49762B812941595C00D3DD18 /* AppDelegate.swift */; };
 		49D812F9293D1C79009A2748 /* testAlarm.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = 49D812F8293D1C79009A2748 /* testAlarm.mp3 */; };
 		49D812FD293F7FB5009A2748 /* MyUserNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D812FC293F7FB5009A2748 /* MyUserNotifications.swift */; };
 		49E703F029353A150035215F /* CreditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E703EF29353A150035215F /* CreditView.swift */; };
@@ -91,6 +92,7 @@
 		494967C62940EAC8001E5E8A /* openSideMenu.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = openSideMenu.wav; sourceTree = "<group>"; };
 		49762B7D294151C300D3DD18 /* closeSideMenu.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; name = closeSideMenu.wav; path = ../../../RaniPaper_SFX/closeSideMenu.wav; sourceTree = "<group>"; };
 		49762B7F294151DB00D3DD18 /* BGM.wav */ = {isa = PBXFileReference; lastKnownFileType = audio.wav; path = BGM.wav; sourceTree = "<group>"; };
+		49762B812941595C00D3DD18 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		49D812F8293D1C79009A2748 /* testAlarm.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = testAlarm.mp3; sourceTree = "<group>"; };
 		49D812FC293F7FB5009A2748 /* MyUserNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyUserNotifications.swift; sourceTree = "<group>"; };
 		49E703EF29353A150035215F /* CreditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreditView.swift; sourceTree = "<group>"; };
@@ -283,6 +285,7 @@
 				D86ACE22292DE272002C8E89 /* Extension */,
 				D86ACE1B292DDF00002C8E89 /* ViewModel */,
 				D86ACE19292DDDA4002C8E89 /* View */,
+				49762B812941595C00D3DD18 /* AppDelegate.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -587,6 +590,7 @@
 				49E703F029353A150035215F /* CreditView.swift in Sources */,
 				7B796F94293D74BB00799616 /* HapticManager.swift in Sources */,
 				D8D549C429362A47001E4287 /* KeyboardHandler.swift in Sources */,
+				49762B822941595C00D3DD18 /* AppDelegate.swift in Sources */,
 				D8FF935A293A57A700B0F475 /* LargeStickerView.swift in Sources */,
 				49E703F029353A150035215F /* CreditView.swift in Sources */,
 				492DB7442931202B0027EEB1 /* DummyView2.swift in Sources */,

--- a/RaniPaper/Info.plist
+++ b/RaniPaper/Info.plist
@@ -16,6 +16,9 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>
+		<string>fetch</string>
+		<string>processing</string>
+		<string>remote-notification</string>
 	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>

--- a/RaniPaper/RaniPaperApp.swift
+++ b/RaniPaper/RaniPaperApp.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 @main
 struct RaniPaperApp: App {
+    @UIApplicationDelegateAdaptor var delegate: AppDelegate
+    
     var body: some Scene {
         WindowGroup {
             MainView().environmentObject(UserState.shared)

--- a/RaniPaper/Source/AppDelegate.swift
+++ b/RaniPaper/Source/AppDelegate.swift
@@ -1,0 +1,57 @@
+//
+//  AppDelegate.swift
+//  RaniPaper
+//
+//  Created by SeaSalt on 2022/12/08.
+//
+
+import Foundation
+import UIKit
+import UserNotifications
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+    let center = UNUserNotificationCenter.current()
+    
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        center.delegate = self
+        print("didFinishLaunchingWithOptions")
+        return true
+    }
+    
+    func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        center.delegate = self
+        print("willFinishLaunchingWithOptions")
+        return true
+    }
+}
+
+// Notification 관련 extension
+extension AppDelegate: UNUserNotificationCenterDelegate{
+    // Notification을 클릭하면 실행될 함수
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        
+        let application = UIApplication.shared
+        
+        print("Execute didReceive")
+        
+        // Notification Center에 신호를 post
+        if application.applicationState == .active{
+            print("앱 켜짐")
+        }
+        
+        if application.applicationState == .background{
+            print("앱 꺼짐")
+        }
+        
+        NotificationCenter.default.post(name: NSNotification.Name("Noti Tabbed"), object: nil)
+        print("✅ Noti Clicked")
+    }
+    
+    // app이 forground 상태일 때 실행할 함수
+    func userNotificationCenter(_ center: UNUserNotificationCenter, willPresent notification: UNNotification, withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        print("Execute willPresent")
+        completionHandler([.banner, .sound])
+    }
+}
+
+// force quit 상황에서는 작동하지 않음

--- a/RaniPaper/Source/View/MainView/MainView.swift
+++ b/RaniPaper/Source/View/MainView/MainView.swift
@@ -28,6 +28,11 @@ struct MainView: View {
 //                        }
 //                    }
 
+                    NotificationCenter.default.addObserver(forName: NSNotification.Name("Noti Tabbed"), object: nil, queue: .main){(_) in
+                        
+                        viewModel.selection = .diary
+                    }
+                    
                     DispatchQueue.main.asyncAfter(deadline: .now()+2) {
                         withAnimation {
                             viewModel.isLoading.toggle()
@@ -61,7 +66,12 @@ struct MainView: View {
                         }
                     }
                     MenuView(selection: $viewModel.selection)
-                }.environmentObject(UserState.shared)
+                }
+//                .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification, object: nil)){(_) in
+//                    print("Test")
+//                    
+//                }
+                .environmentObject(UserState.shared)
             }
         }
     }

--- a/RaniPaper/Source/View/MenuView/MenuView.swift
+++ b/RaniPaper/Source/View/MenuView/MenuView.swift
@@ -91,12 +91,3 @@ struct MenuView_Previews: PreviewProvider {
         }
     }
 }
-
-extension DragGesture{
-    func playOpenSound(isOpen: Bool) -> some Gesture{
-        if !isOpen{
-            MySoundSetting.openSideMenu.play()
-        }
-        return self
-    }
-}

--- a/RaniPaper/Source/View/MenuView/MenuView.swift
+++ b/RaniPaper/Source/View/MenuView/MenuView.swift
@@ -26,7 +26,6 @@ struct MenuView: View {
                 } else {
                     if $0.startLocation.x > Menu.openEdge{
                         viewModel.Offset = Menu.minOffset + $0.translation.width > Menu.maxOffset ? Menu.minOffset + $0.translation.width : Menu.maxOffset
-                        
                         if !isPlayed{
                             MySoundSetting.openSideMenu.play()
                             isPlayed = true


### PR DESCRIPTION
## 배경

- 푸시 알림 클릭 시 다이어리뷰로 바로 이동할 수 있어야 했습니다
- 앱이 foreground 상태일 때 푸시 알림이 뜨지 않는 현상을 수정해야 했습니다

## 작업 내용

- background 상태에서 usernotification의 receive를 확인할 수 있도록 AppDelegate와 관련 extension을 생성했습니다
- 푸시 알림 클릭 시 notificationcenter에 신호를 post하고 MainView에서 addObserver를 통해 신호를 수신하도록 했습니다

## 작업 필요

- 앱을 force-quit 한 경우 앞서 작업한 내용이 적용 안되는 부분 수정 필요