### PR TITLE
⚡ userState를 통해 사이드 메뉴의 enable을 결정할 수 있게 합니다.

### DIFF
--- a/RaniPaper/Source/UserState.swift
+++ b/RaniPaper/Source/UserState.swift
@@ -11,10 +11,12 @@ class UserState: ObservableObject {
     static let shared = UserState()
     
     @Published var userType: UserType
+    @Published var isMenuEnable: Bool
     
     init() {
         print("✅ UserState 생성")
         self.userType = .none
+        self.isMenuEnable = true
         fetch()
     }
     

--- a/RaniPaper/Source/View/HomeView/HomeView.swift
+++ b/RaniPaper/Source/View/HomeView/HomeView.swift
@@ -26,6 +26,12 @@ struct HomeView: View {
                         NavigationLink {
                             MailBoxAnimationView(viewModel: viewModel)
                                 .navigationBarBackButtonHidden()
+                                .onAppear{
+                                    userState.isMenuEnable = false
+                                }
+                                .onDisappear{
+                                    userState.isMenuEnable = true
+                                }
                         } label: {
                             Rectangle().strokeBorder(lineWidth: 3) // 터치 범위
                                 .frame(width:100, height: 180)

--- a/RaniPaper/Source/View/MenuView/MenuView.swift
+++ b/RaniPaper/Source/View/MenuView/MenuView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct MenuView: View {
+    @EnvironmentObject var userState: UserState
     @StateObject var viewModel = MenuViewModel()
     @Binding var selection: ViewSelection
     @State var isPlayed = false
@@ -72,7 +73,7 @@ struct MenuView: View {
             .animation(.linear, value: viewModel.Offset)
         }
         .contentShape(Rectangle())
-        .gesture(drag)
+        .gesture(userState.isMenuEnable ? drag : nil)
         .ignoresSafeArea()
     }
 }
@@ -81,6 +82,7 @@ struct prev: View{
     @State var select: ViewSelection = .home
     var body: some View{
         MenuView(selection: $select)
+            .environmentObject(UserState.shared)
     }
 }
 


### PR DESCRIPTION
## 배경

- 갤러리 뷰에서 사이드 메뉴가 열리지 않아야 합니다.

## 작업 내용

- environmentObject인 userState 내에 isMenuEnable 변수를 통해 사이드 메뉴의 enable을 결정할 수 있게 합니다.
- mailBoxAnimationView 등장과 소멸 시 isMenuEnable를 변경해 애니메이션 화면에서부터 사이드 메뉴를 열 수 없게 합니다.