### PR TITLE
⚡ 소리 음량 테스트를 위해 설정 뷰에 슬라이더를 추가합니다

### DIFF
--- a/RaniPaper/Source/Utils/MySoundSetting.swift
+++ b/RaniPaper/Source/Utils/MySoundSetting.swift
@@ -14,6 +14,7 @@ class MySoundSetting: ObservableObject{
     let soundType: SoundType
     var player: AVAudioPlayer?
     var isEnable: Bool = true
+    var volume: Float = 1.0
     
     private init(url urlName: String, extension extensionName: String, _ type: SoundType){
         self.urlName = urlName
@@ -54,6 +55,9 @@ class MySoundSetting: ObservableObject{
         default:
             break
         }
+        
+        //볼륨 설정
+        player?.setVolume(volume, fadeDuration: 0)
         
         // 소리 설정이 활성 상태면 음원 재생
         if self.isEnable{
@@ -105,6 +109,11 @@ class MySoundSetting: ObservableObject{
         default:
             break
         }
+    }
+    
+    func setChannelVolume(_ volume: Float){
+        self.player?.setVolume(volume, fadeDuration: 0)
+        self.volume = volume
     }
 }
 

--- a/RaniPaper/Source/View/SettingView/SettingView.swift
+++ b/RaniPaper/Source/View/SettingView/SettingView.swift
@@ -12,6 +12,8 @@ struct SettingView: View {
     @Environment(\.openURL) var openURL
     @ObservedObject var viewModel = SettingViewModel()
     @State var isOnboardOn = false
+    @State var BGMVolume = 1.0
+    @State var SFXVolume = 1.0
     var body: some View {
         ZStack{
             Image("main_static")
@@ -93,6 +95,24 @@ struct SettingView: View {
                                         }
                                         .padding(.top, height * 0.09)
                                     }
+                                    
+                                    Slider(value: $BGMVolume, in: 0...1.0, step: 0.05,
+                                           onEditingChanged: {(_) in
+                                        MySoundSetting.BGM.setChannelVolume(Float(BGMVolume))
+                                        }
+                                    )
+                                    
+                                    Text("BGM: \(BGMVolume)")
+                                    
+                                    Slider(value: $SFXVolume, in: 0...1.0, step: 0.05,
+                                           onEditingChanged: {(_) in
+                                        for instance in MySoundSetting.getInstance(soundType: .SFX){
+                                            instance.setChannelVolume(Float(SFXVolume))
+                                        }
+                                    }
+                                    )
+                                    
+                                    Text("SFX: \(SFXVolume)")
                                     Spacer()
                                         .padding(.bottom)
                                 }


### PR DESCRIPTION
## 배경

- 앱의 배경음과 효과음이 실기기에서 너무 크게 나오는 문제가 있었습니다.

## 작업 내용

-  MySoundSetting 내에서 각 avaudioplayer의 볼륨을 조절할 수 있게 합니다.
- 볼륨의 적절 수치를 실기기에서 테스트하기 위해 설정 뷰에 슬라이더를 통해 각 음성 볼륨을 조절할 수 있게 합니다.

## 추가 사항

- 테스트만을 위해 간략하게 구현한 슬라이더이기 때문에 사소한 기능 문제가 있을 수 있습니다.(예: 설정 뷰를 나갔다 돌아오면 슬라이더가 1로 초기화돼 있는 현상)