### PR TITLE
⚡ 설정 화면 배경 및 아이콘을 수정합니다 

### DIFF
--- a/RaniPaper/Source/View/SettingView/SettingView.swift
+++ b/RaniPaper/Source/View/SettingView/SettingView.swift
@@ -17,13 +17,11 @@ struct SettingView: View {
     @State var SFXVolume = 1.0
     var body: some View {
         ZStack{
-            Image("main_static")
-                .resizable()
-                .aspectRatio(contentMode: .fill)
+            BackgroundView()
                 .blur(radius: 5)
             VStack(spacing: 0){
                 if userState.userType == .viichan{
-                    Image("viic1")
+                    Image("viichan")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: ScreenSize.width * 0.24)
@@ -137,6 +135,7 @@ struct SettingView: View {
                 }
                 .frame(height: ScreenSize.height * 0.82)
             }
+//            .background(.ultraThinMaterial)
             
             OnBoardView(currentView: .setting)
             


### PR DESCRIPTION
## 배경

- userState가 viichan일 때 설정 화면 상단 아이콘이 나오지 않는 현상이 있었습니다
- 설정 화면 배경과 홈 화면 배경이 달라 이질감이 드는 부분이 있었습니다

## 작업 내용

- userState가 viichan일 때도 정상적으로 아이콘이 나오게 이미지 asset 이름을 변경했습니다
- 설정 화면의 배경도 홈 화면과 동일하게 BackgroundView를 적용합니다 