### PR TITLE
⚡ RollingPaperDetailView의 가독성 및 재사용성을 향상 시킵니다.

### DIFF
--- a/RaniPaper.xcodeproj/project.pbxproj
+++ b/RaniPaper.xcodeproj/project.pbxproj
@@ -44,7 +44,7 @@
 		7B796F8929384FEA00799616 /* MemoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B796F8829384FEA00799616 /* MemoModel.swift */; };
 		7B796F8E2938DA9D00799616 /* AlertToast in Frameworks */ = {isa = PBXBuildFile; productRef = 7B796F8D2938DA9D00799616 /* AlertToast */; };
 		7B796F90293A22FA00799616 /* MailBoxAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B796F8F293A22FA00799616 /* MailBoxAnimationView.swift */; };
-		7B796F92293A462A00799616 /* RollingPaperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B796F91293A462A00799616 /* RollingPaperView.swift */; };
+		7B796F92293A462A00799616 /* RollingPaperDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B796F91293A462A00799616 /* RollingPaperDetailView.swift */; };
 		7B796F94293D74BB00799616 /* HapticManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B796F93293D74BB00799616 /* HapticManager.swift */; };
 		7B796F96293E312000799616 /* UserState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B796F95293E312000799616 /* UserState.swift */; };
 		D805DB35294877F30053723E /* ChosunNm.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D805DB33294877F30053723E /* ChosunNm.ttf */; };
@@ -128,7 +128,7 @@
 		7B796F8629378CD500799616 /* HomeViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		7B796F8829384FEA00799616 /* MemoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoModel.swift; sourceTree = "<group>"; };
 		7B796F8F293A22FA00799616 /* MailBoxAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailBoxAnimationView.swift; sourceTree = "<group>"; };
-		7B796F91293A462A00799616 /* RollingPaperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingPaperView.swift; sourceTree = "<group>"; };
+		7B796F91293A462A00799616 /* RollingPaperDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingPaperDetailView.swift; sourceTree = "<group>"; };
 		7B796F93293D74BB00799616 /* HapticManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HapticManager.swift; sourceTree = "<group>"; };
 		7B796F95293E312000799616 /* UserState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserState.swift; sourceTree = "<group>"; };
 		D805DB33294877F30053723E /* ChosunNm.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = ChosunNm.ttf; sourceTree = "<group>"; };
@@ -301,7 +301,7 @@
 			children = (
 				7B796F8429378CB300799616 /* HomeView.swift */,
 				7B796F8F293A22FA00799616 /* MailBoxAnimationView.swift */,
-				7B796F91293A462A00799616 /* RollingPaperView.swift */,
+				7B796F91293A462A00799616 /* RollingPaperDetailView.swift */,
 				4983001A294F0CEF007BB571 /* BackgroundView.swift */,
 			);
 			path = HomeView;
@@ -671,7 +671,7 @@
 				493526FE292FFC030066F083 /* MenuModel.swift in Sources */,
 				D86ACE5B293475F7002C8E89 /* CalendarView.swift in Sources */,
 				D8D549C02934FB06001E4287 /* EditTaskView.swift in Sources */,
-				7B796F92293A462A00799616 /* RollingPaperView.swift in Sources */,
+				7B796F92293A462A00799616 /* RollingPaperDetailView.swift in Sources */,
 				D86ACE20292DE0E0002C8E89 /* LaunchView.swift in Sources */,
 				7B796F96293E312000799616 /* UserState.swift in Sources */,
 				D8FF9358293A57A700B0F475 /* SmallStickerView.swift in Sources */,

--- a/RaniPaper/Source/View/GalleryView/GalleryView.swift
+++ b/RaniPaper/Source/View/GalleryView/GalleryView.swift
@@ -39,7 +39,7 @@ struct GalleryView: View {
             }
         }
         .fullScreenCover(item: $selectedRollingPaper) { rollingPaper in
-            rollingPaperDetailView(rollingPaper)
+            RollingPaperDetailView(rollingPaper: rollingPaper)
         }
         
     }
@@ -80,43 +80,28 @@ struct GalleryView: View {
         }
     }
     
-    private func rollingPaperDetailView(_ rollingPaper: RollingPaper) -> some View {
-        ZStack {
-            Color.black.ignoresSafeArea()
-            VStack {
-                Button(action: { selectedRollingPaper = nil }){
-                    Text("닫기 버튼")
-                }
-                Image(rollingPaper.backgroundImage).resizable().scaledToFit()
-                    .overlay {
-                        Image(rollingPaper.contentImage).resizable().padding(80)
-                    }
-            }
-        }
-    }
-    
 }
 
 fileprivate struct GalleryRollingPaperView: View {
     let rollingPaper: RollingPaper
-    var size: CGSize
-    var messageOffset: CGSize = .init(width: 0, height: 0)
+    private var messageSize: CGSize
+    private var messageOffset: CGSize = .init(width: 0, height: 0)
     
     init(rollingPaper: RollingPaper) {
         self.rollingPaper = rollingPaper
 
         switch rollingPaper.backgroundImage {
         case "paper_rectangle":
-            size = .init(width: 100, height: 100)
+            messageSize = .init(width: 100, height: 100)
         case "paper_butterfly":
-            size = .init(width: 95, height: 95)
+            messageSize = .init(width: 95, height: 95)
         case "paper_heart":
-            size = .init(width: 80, height: 80)
+            messageSize = .init(width: 80, height: 80)
             messageOffset = .init(width: 0, height: -9)
         case "paper_flower":
-            size = .init(width: 80, height: 80)
+            messageSize = .init(width: 80, height: 80)
         default:
-            size = .init(width: 75, height: 75)
+            messageSize = .init(width: 75, height: 75)
         }
     }
     
@@ -125,7 +110,7 @@ fileprivate struct GalleryRollingPaperView: View {
             .frame(width: 125, height: 125)
             .overlay {
                 Image(rollingPaper.contentImage).resizable()
-                    .frame(width: size.width, height: size.height)
+                    .frame(width: messageSize.width, height: messageSize.height)
                     .offset(messageOffset)
                     //.background { Color.white }
             }

--- a/RaniPaper/Source/View/HomeView/MailBoxAnimationView.swift
+++ b/RaniPaper/Source/View/HomeView/MailBoxAnimationView.swift
@@ -71,7 +71,7 @@ struct MailBoxAnimationView: View {
                     .padding(.bottom, SafeAreaInsets.bottom + 30)
             }// ZStack
             .fullScreenCover(isPresented: $shouldShowRollingPaper) {
-                RollingPaperView(rollingPaper: rollingPaper!, size: CGSize(width: 220, height: 220))
+                RollingPaperView(rollingPaper: rollingPaper!)
                     .onAppear {
                         HapticManager.shared.impact(style: .soft)
                     }

--- a/RaniPaper/Source/View/HomeView/MailBoxAnimationView.swift
+++ b/RaniPaper/Source/View/HomeView/MailBoxAnimationView.swift
@@ -71,10 +71,15 @@ struct MailBoxAnimationView: View {
                     .padding(.bottom, SafeAreaInsets.bottom + 30)
             }// ZStack
             .fullScreenCover(isPresented: $shouldShowRollingPaper) {
-                RollingPaperView(rollingPaper: rollingPaper!)
-                    .onAppear {
-                        HapticManager.shared.impact(style: .soft)
-                    }
+                RollingPaperDetailView(rollingPaper: rollingPaper!, background: {
+                    Image("mail_box_ready")
+                        .resizable()
+                        .ignoresSafeArea()
+                        .blur(radius: 30)
+                })
+                .onAppear {
+                    HapticManager.shared.impact(style: .soft)
+                }
             }.ignoresSafeArea()
             
         }

--- a/RaniPaper/Source/View/HomeView/RollingPaperDetailView.swift
+++ b/RaniPaper/Source/View/HomeView/RollingPaperDetailView.swift
@@ -7,14 +7,19 @@
 
 import SwiftUI
 
-struct RollingPaperView: View {
+struct RollingPaperDetailView<Background: View>: View {
     @Environment(\.dismiss) private var dismiss
     let rollingPaper: RollingPaper
+    private var background: () -> Background
     private let messageRatio: CGFloat
     @State private var messageOffset: CGSize = .init(width: 0, height: 0)
     
-    init(rollingPaper: RollingPaper) {
+    init(
+        rollingPaper: RollingPaper,
+        @ViewBuilder background: @escaping () -> Background = { Color.black.ignoresSafeArea() }
+    ) {
         self.rollingPaper = rollingPaper
+        self.background = background
         
         switch rollingPaper.backgroundImage {
         case "paper_rectangle":
@@ -33,10 +38,7 @@ struct RollingPaperView: View {
     
     var body: some View {
         ZStack {
-            Image("mail_box_ready")
-                .resizable()
-                .ignoresSafeArea()
-                .blur(radius: 30)
+            background()
             
             VStack {
                 HStack {
@@ -76,9 +78,13 @@ struct RollingPaperView: View {
     }
 }
 
-struct RollingPaperView_Previews: PreviewProvider {
+struct RollingPaperDetailView_Previews: PreviewProvider {
     static var previews: some View {
-        RollingPaperView(rollingPaper: RollingPaper(contentImage: "rolling_paper_29", backgroundImage: "paper_flower"))
-        RollingPaperView(rollingPaper: RollingPaper(contentImage: "rolling_paper_29", backgroundImage: "paper_flower")).previewDevice("iPhone 8")
+        RollingPaperDetailView(rollingPaper: RollingPaper(contentImage: "rolling_paper_29", backgroundImage: "paper_heart")) {
+            Image("mail_box_ready")
+                .resizable()
+                .ignoresSafeArea()
+                .blur(radius: 30)
+        }
     }
 }

--- a/RaniPaper/Source/View/HomeView/RollingPaperView.swift
+++ b/RaniPaper/Source/View/HomeView/RollingPaperView.swift
@@ -10,7 +10,26 @@ import SwiftUI
 struct RollingPaperView: View {
     @Environment(\.dismiss) private var dismiss
     let rollingPaper: RollingPaper
-    let size: CGSize
+    private let messageRatio: CGFloat
+    @State private var messageOffset: CGSize = .init(width: 0, height: 0)
+    
+    init(rollingPaper: RollingPaper) {
+        self.rollingPaper = rollingPaper
+        
+        switch rollingPaper.backgroundImage {
+        case "paper_rectangle":
+            messageRatio = 0.9
+        case "paper_butterfly":
+            messageRatio = 0.8
+        case "paper_heart":
+            messageRatio = 0.6
+            messageOffset = .init(width: 0, height: -20)
+        case "paper_flower":
+            messageRatio = 0.6
+        default:
+            messageRatio = 0.6
+        }
+    }
     
     var body: some View {
         ZStack {
@@ -33,11 +52,14 @@ struct RollingPaperView: View {
                 Image(rollingPaper.backgroundImage)
                     .resizable()
                     .aspectRatio(CGSize(width: 1, height: 1),contentMode: .fit)
+                    .frame(width: ScreenSize.width)
                     .overlay {
                         Image(rollingPaper.contentImage)
                             .resizable()
-                            .frame(width: size.width, height: size.height)
+                            .aspectRatio(CGSize(width: 1, height: 1),contentMode: .fit)
+                            .frame(width: ScreenSize.width * messageRatio)
                             //.background { Color.white }
+                            .offset(messageOffset)
                     }
                 
                 Spacer()
@@ -56,7 +78,7 @@ struct RollingPaperView: View {
 
 struct RollingPaperView_Previews: PreviewProvider {
     static var previews: some View {
-        RollingPaperView(rollingPaper: RollingPaper(contentImage: "rolling_paper_29", backgroundImage: "paper_flower"), size: CGSize(width: 220, height: 220))
-        RollingPaperView(rollingPaper: RollingPaper(contentImage: "rolling_paper_29", backgroundImage: "paper_flower"), size: CGSize(width: 220, height: 220)).previewDevice("iPhone 8")
+        RollingPaperView(rollingPaper: RollingPaper(contentImage: "rolling_paper_29", backgroundImage: "paper_flower"))
+        RollingPaperView(rollingPaper: RollingPaper(contentImage: "rolling_paper_29", backgroundImage: "paper_flower")).previewDevice("iPhone 8")
     }
 }


### PR DESCRIPTION
### 배경
- 용지의 종류에 따라 공간이 있음에도 불구하고 내용을 작게 보여주었습니다.

### 작업 내용
- 용지의 종류에 따라 내용의 크기를 조절합니다.
- RollingPaperView 에서 RollingPaperDetailView 로 이름을 변경합니다.
- RollingPaperDetailView 의 기존에 고정된 우체통 블러 배경 방식에서, 호출하는 곳에서 원하는 배경으로 변경할 수 있도록 변경합니다. (기본값은 검은 배경)

``` Swift

struct RollingPaperDetailView<Background: View>: View {
    let rollingPaper: RollingPaper
    private var background: () -> Background

    init(
        rollingPaper: RollingPaper,
        @ViewBuilder background: @escaping () -> Background = { Color.black.ignoresSafeArea() }
    ) {
        self.rollingPaper = rollingPaper
        self.background = background

```