### PR TITLE
⚡ 설정 화면에 테스트용 슬라이더를 제거하고 소리 볼륨을 고정시킵니다

### DIFF
--- a/RaniPaper/Source/Utils/MySoundSetting.swift
+++ b/RaniPaper/Source/Utils/MySoundSetting.swift
@@ -14,7 +14,6 @@ class MySoundSetting: ObservableObject{
     let soundType: SoundType
     var player: AVAudioPlayer?
     var isEnable: Bool = true
-    var volume: Float = 1.0
     
     private init(url urlName: String, extension extensionName: String, _ type: SoundType){
         self.urlName = urlName
@@ -48,16 +47,16 @@ class MySoundSetting: ObservableObject{
             print("🔥 음원을 불러오는데 오류가 발생했습니다.\(error.localizedDescription)")
         }
         
-        // 소리 종류에 따라 루프 여부 결정
+        // 소리 종류에 따라 설정 변경
         switch soundType {
-        case .BGM, .ALARM:
+        case .BGM:
             player?.numberOfLoops = -1
+            player?.setVolume(0.5, fadeDuration: 0)
         default:
-            break
+            player?.setVolume(0.75, fadeDuration: 0)
         }
         
         //볼륨 설정
-        player?.setVolume(volume, fadeDuration: 0)
         
         // 소리 설정이 활성 상태면 음원 재생
         if self.isEnable{
@@ -113,7 +112,6 @@ class MySoundSetting: ObservableObject{
     
     func setChannelVolume(_ volume: Float){
         self.player?.setVolume(volume, fadeDuration: 0)
-        self.volume = volume
     }
 }
 

--- a/RaniPaper/Source/View/SettingView/SettingView.swift
+++ b/RaniPaper/Source/View/SettingView/SettingView.swift
@@ -13,8 +13,6 @@ struct SettingView: View {
     @ObservedObject var viewModel = SettingViewModel()
     @State var isOnBoard = MyUserDefaults.shared.getValue(key: "SettingOnBoard") as? Bool ?? true
     @State var isReOnboard = false
-    @State var BGMVolume = 1.0
-    @State var SFXVolume = 1.0
     var body: some View {
         ZStack{
             BackgroundView()
@@ -95,23 +93,6 @@ struct SettingView: View {
                                         .padding(.top, height * 0.09)
                                     }
                                     
-                                    Slider(value: $BGMVolume, in: 0...1.0, step: 0.05,
-                                           onEditingChanged: {(_) in
-                                        MySoundSetting.BGM.setChannelVolume(Float(BGMVolume))
-                                        }
-                                    )
-                                    
-                                    Text("BGM: \(BGMVolume)")
-                                    
-                                    Slider(value: $SFXVolume, in: 0...1.0, step: 0.05,
-                                           onEditingChanged: {(_) in
-                                        for instance in MySoundSetting.getInstance(soundType: .SFX){
-                                            instance.setChannelVolume(Float(SFXVolume))
-                                        }
-                                    }
-                                    )
-                                    
-                                    Text("SFX: \(SFXVolume)")
                                     Spacer()
                                         .padding(.bottom)
                                 }


### PR DESCRIPTION
## 배경

- 설정 화면에 테스트에 사용했던 슬라이더를 제거해야 했습니다
- 음향의 볼륨을 적정 수치로 조절해야 했습니다

## 작업 내용

- 설정 화면의 슬라이더를 제거합니다
- 배경음의 볼륨을 기존의 0.5배, 효과음의 볼륨을 기존의 0.75배로 조정합니다