### PR TITLE
⚡ 사이드 메뉴 관련 버그를 수정합니다

### DIFF
--- a/RaniPaper/Resource/Constants/Enum.swift
+++ b/RaniPaper/Resource/Constants/Enum.swift
@@ -33,8 +33,9 @@ enum SafeAreaInsets {
 enum Menu {
     static let minOffset = ScreenSize.width
     static let maxOffset = ScreenSize.width * 0.5
-    static let threshold = Menu.maxOffset * 1.3
-    static let openEdge = ScreenSize.width * 0.85
+    static let openThreshold = Menu.maxOffset * 1.7
+    static let closeThreshold = Menu.maxOffset * 1.2
+    static let openEdge = ScreenSize.width * 0.95
 }
 
 enum ViewSelection: CaseIterable {

--- a/RaniPaper/Resource/Constants/Enum.swift
+++ b/RaniPaper/Resource/Constants/Enum.swift
@@ -35,7 +35,7 @@ enum Menu {
     static let maxOffset = ScreenSize.width * 0.5
     static let openThreshold = Menu.maxOffset * 1.7
     static let closeThreshold = Menu.maxOffset * 1.2
-    static let openEdge = ScreenSize.width * 0.95
+    static let openEdge = ScreenSize.width * 0.92
 }
 
 enum ViewSelection: CaseIterable {

--- a/RaniPaper/Source/Extension/Extension.swift
+++ b/RaniPaper/Source/Extension/Extension.swift
@@ -88,6 +88,18 @@ extension Color
     public static var onBoardGreen:Color{
         return Color.init(hexcode: "599E58")
     }
+    
+    public static var menuHomeOnPress:Color{
+        return Color.init(hexcode: "FFC5BC")
+    }
+    
+    public static var menuCreditOnPress:Color{
+        return Color.init(hexcode: "D3DF88")
+    }
+    
+    public static var menuOnPress:Color{
+        return Color.init(hexcode: "C0E4C0")
+    }
 }
 
 extension UIDevice {
@@ -164,6 +176,17 @@ extension ViewSelection: Equatable{
         case .setting: return "setting"
         case .info: return "info"
         case .credit: return "credit"
+        }
+    }
+    
+    var ButtonName: String{
+        switch self{
+        case .home: return "홈"
+        case .diary: return "다이어리"
+        case .memo: return "메모"
+        case .setting: return "설정"
+        case .info: return "앱 정보"
+        case .credit: return "크레딧"
         }
     }
     

--- a/RaniPaper/Source/View/MainView/MainView.swift
+++ b/RaniPaper/Source/View/MainView/MainView.swift
@@ -62,6 +62,8 @@ struct MainView: View {
                             CreditView()
                         }
                     }
+                }
+                .overlay{
                     MenuView(selection: $viewModel.selection)
                 }
 //                .onReceive(NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification, object: nil)){(_) in

--- a/RaniPaper/Source/View/MenuView/MenuView.swift
+++ b/RaniPaper/Source/View/MenuView/MenuView.swift
@@ -12,10 +12,12 @@ struct MenuView: View {
     @StateObject var viewModel = MenuViewModel()
     @Binding var selection: ViewSelection
     @State var isPlayed = false
+    @State var gestureState: String = ""
     var body: some View {
                 
         let drag = DragGesture()
             .onChanged{
+                gestureState = "OnChanged"
                 if viewModel.isOpen{
                     let cmp = Menu.maxOffset - $0.startLocation.x
                     if ($0.translation.width > 0) && (cmp > 0) {
@@ -35,7 +37,8 @@ struct MenuView: View {
                 }
             }
             .onEnded{ _ in
-                if viewModel.Offset < Menu.threshold{
+                gestureState = "OnEnded"
+                if viewModel.Offset < (viewModel.isOpen ? Menu.closeThreshold : Menu.openThreshold){
                     withAnimation{
                         viewModel.Offset = Menu.maxOffset
                         viewModel.isOpen = true
@@ -71,9 +74,11 @@ struct MenuView: View {
             .offset(x: viewModel.Offset)
             .transition(.move(edge: .trailing))
             .animation(.linear, value: viewModel.Offset)
+            
+            Text(gestureState)
         }
         .contentShape(Rectangle())
-        .gesture(userState.isMenuEnable ? drag : nil)
+        .highPriorityGesture(userState.isMenuEnable ? drag : nil)
         .ignoresSafeArea()
     }
 }

--- a/RaniPaper/Source/View/MenuView/MenuView.swift
+++ b/RaniPaper/Source/View/MenuView/MenuView.swift
@@ -13,7 +13,6 @@ struct MenuView: View {
     @Binding var selection: ViewSelection
     @GestureState var dragState: (CGFloat, Bool) = (Menu.minOffset, false)
     @State var isPlayed = false
-    @State var gestureState = false
     var body: some View {
                 
         let drag = DragGesture(minimumDistance: 20)
@@ -34,7 +33,6 @@ struct MenuView: View {
                 }
             }
             .onChanged{
-                gestureState = true
                 if !viewModel.isOpen{
                     if $0.startLocation.x > Menu.openEdge && !isPlayed{
                         MySoundSetting.openSideMenu.play()
@@ -82,8 +80,6 @@ struct MenuView: View {
             .offset(x: dragState.1 ? dragState.0 : viewModel.Offset)
             .transition(.move(edge: .trailing))
             .animation(.linear, value: viewModel.Offset)
-            
-            Text("\(dragState.0), \(String(dragState.1)), \(viewModel.Offset), \(String(gestureState))")
         }
         .contentShape(Rectangle())
         .highPriorityGesture(userState.isMenuEnable ? drag : nil)

--- a/RaniPaper/Source/View/MenuView/MenuView.swift
+++ b/RaniPaper/Source/View/MenuView/MenuView.swift
@@ -14,75 +14,30 @@ struct MenuView: View {
     @GestureState var dragState: (CGFloat, Bool) = (Menu.minOffset, false)
     @State var isPlayed = false
     var body: some View {
-                
-        let drag = DragGesture(minimumDistance: 20)
-            .updating($dragState){(value, state, transcation) in
-                state.1 = true
-                if viewModel.isOpen{
-                    let cmp = Menu.maxOffset - value.startLocation.x
-                    if (value.translation.width > 0) && (cmp > 0) {
-                        state.0 = Menu.maxOffset + value.translation.width - cmp
-                    }
-                    else if (value.translation.width > 0) && (cmp < 0) {
-                        state.0 = Menu.maxOffset + value.translation.width
-                    }
-                } else {
-                    if value.startLocation.x > Menu.openEdge{
-                        state.0 = Menu.minOffset + value.translation.width > Menu.maxOffset ? Menu.minOffset + value.translation.width : Menu.maxOffset
-                    }
-                }
-            }
-            .onChanged{
-                if !viewModel.isOpen{
-                    if $0.startLocation.x > Menu.openEdge && !isPlayed{
-                        MySoundSetting.openSideMenu.play()
-                        isPlayed = true
-                    }
-                }
-                viewModel.Offset = dragState.0
-            }
-            .onEnded{ _ in
-                if viewModel.Offset < (viewModel.isOpen ? Menu.closeThreshold : Menu.openThreshold){
-                    withAnimation{
-                        viewModel.Offset = Menu.maxOffset
-                        viewModel.isOpen = true
-                    }
-                }
-                else {
-                    if viewModel.isOpen{
-                        MySoundSetting.closeSideMenu.play()
-                    }
-                    withAnimation{
-                        viewModel.isOpen = false
-                        viewModel.Offset = Menu.minOffset
-                    }
-                }
-                isPlayed = false
-            }
         
         ZStack{
             Color.black
-                .opacity(viewModel.Offset == Menu.minOffset ? 0 : Double((ScreenSize.width-viewModel.Offset))/1300)
+                .opacity(viewModel.Offset == Menu.minOffset ? 0 : Double((ScreenSize.width-viewModel.Offset))/1300+0.05)
                 .animation(.easeIn, value: viewModel.Offset)
-                .onTapGesture {
+                .gesture(TapGesture().onEnded{
                     if viewModel.isOpen{
                         MySoundSetting.closeSideMenu.play()
                         viewModel.Offset = Menu.minOffset
                         viewModel.isOpen = false
                     }
-                }
+                })
             
             SideMenuView(isOpen: $viewModel.isOpen,
                          offset: $viewModel.Offset,
                          selection: $selection,
                          viewModel: viewModel)
             .shadow(radius: 3)
-            .offset(x: dragState.1 ? dragState.0 : viewModel.Offset)
+            .offset(x: viewModel.Offset)
             .transition(.move(edge: .trailing))
             .animation(.linear, value: viewModel.Offset)
         }
         .contentShape(Rectangle())
-        .highPriorityGesture(userState.isMenuEnable ? drag : nil)
+        .modifier(DragGestureViewModifier(offset: $viewModel.Offset, isOpen: $viewModel.isOpen))
         .ignoresSafeArea()
     }
 }
@@ -100,5 +55,100 @@ struct MenuView_Previews: PreviewProvider {
         VStack{
             prev()
         }
+    }
+}
+
+struct DragGestureViewModifier: ViewModifier{
+    @GestureState private var isDragging: Bool = false
+    @State var gestureState: GestureStatus = .idle
+    @State var isPlayed = false
+    @Binding var offset: CGFloat
+    @Binding var isOpen: Bool
+    
+    var onUpdate: ((DragGesture.Value) -> Void)?
+    
+    func body(content: Content) -> some View {
+        content
+            .gesture(
+                DragGesture()
+                    .updating($isDragging){_, isDragging, _ in
+                        isDragging = true
+                    }
+                    .onChanged(onDragChange(_:))
+                    .onEnded(onDragEnded(_:))
+            )
+            .onChange(of: gestureState){ state in
+                guard state == .started else {return}
+                gestureState = .active
+                
+            }
+            .onChange(of: isDragging){ value in
+                if value, gestureState != .started{
+                    gestureState = .started
+                } else if !value, gestureState != .ended{
+                    gestureState = .cancelled
+                    onCancled()
+                }
+            }
+    }
+        
+    func onDragChange(_ value: DragGesture.Value){
+        guard gestureState == .started || gestureState == .active else {return}
+        onUpdate(value: value)
+    }
+        
+    func onDragEnded(_ value: DragGesture.Value){
+        gestureState = .ended
+        onEnd()
+    }
+    
+    func onUpdate(value: DragGesture.Value){
+        if isOpen{
+            let cmp = Menu.maxOffset - value.startLocation.x
+            if (value.translation.width > 0) && (cmp > 0) {
+                offset = max(Menu.maxOffset + value.translation.width - cmp, Menu.maxOffset)
+            }
+            else if (value.translation.width > 0) && (cmp < 0) {
+                offset = max(Menu.maxOffset + value.translation.width, Menu.maxOffset)
+            }
+            else{
+                offset = Menu.maxOffset
+            }
+        } else {
+            if value.startLocation.x > Menu.openEdge{
+                offset = max(Menu.minOffset + value.translation.width, Menu.maxOffset)
+                if !isPlayed{
+                    MySoundSetting.openSideMenu.play()
+                    isPlayed = true
+                }
+            }
+        }
+    }
+    
+    func onEnd(){
+        if offset < (isOpen ? Menu.closeThreshold : Menu.openThreshold){
+            withAnimation{
+                offset = Menu.maxOffset
+                isOpen = true
+            }
+        }
+        else {
+            if isOpen{
+                MySoundSetting.closeSideMenu.play()
+            }
+            withAnimation{
+                isOpen = false
+                offset = Menu.minOffset
+            }
+        }
+        isPlayed = false
+    }
+    
+    func onCancled(){
+        onEnd()
+    }
+    
+    enum GestureStatus: Equatable{
+        case idle, started, active, ended, cancelled
     }
 }

--- a/RaniPaper/Source/View/MenuView/SideMenuView.swift
+++ b/RaniPaper/Source/View/MenuView/SideMenuView.swift
@@ -31,9 +31,12 @@ struct SideMenuView: View {
                                 Button(action:{
                                     isOpen.toggle()
                                     offset = Menu.minOffset
-                                    selection = menu.viewSelection
                                     MySoundSetting.clickSideMenu.play()
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1){
+                                        selection = menu.viewSelection
+                                    }
                                 }) {
+//                                    Image(menu.viewSelection.Name + (selection == menu.viewSelection ? "OnPress" : ""))
                                     Image(menu.viewSelection.Name + (selection == menu.viewSelection ? "OnPress" : ""))
                                         .resizable()
                                         .aspectRatio(contentMode: .fit)
@@ -42,6 +45,7 @@ struct SideMenuView: View {
                             }
                         }
                     }
+//                    TabButtonView(menu: viewModel.menuList[0])
 
                     Spacer()
                     
@@ -52,8 +56,10 @@ struct SideMenuView: View {
                                 Button(action:{
                                     isOpen.toggle()
                                     offset = Menu.minOffset
-                                    selection = menu.viewSelection
                                     MySoundSetting.clickSideMenu.play()
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1){
+                                        selection = menu.viewSelection
+                                    }
                                 }) {
                                     Image(menu.viewSelection.Name + (selection == menu.viewSelection ? "OnPress" : ""))
                                         .resizable()
@@ -86,6 +92,32 @@ struct SideMenuView_Previews: PreviewProvider {
                          selection: .constant(.home),
                          viewModel: MenuViewModel()
                          )
+        }
+    }
+}
+
+extension SideMenuView{
+    func TabButtonView(menu: MenuContent) -> some View{
+        HStack(spacing: 10){
+//            Image(menu.viewSelection.Name)
+            Image("viichan")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(height: ScreenSize.height * 0.044)
+            Text(menu.viewSelection.ButtonName)
+                .font(.efDiary(ScreenSize.width * 0.067))
+                .padding(.trailing, ScreenSize.width * 0.02)
+        }
+        .overlay{
+            if selection == menu.viewSelection{
+                if selection == .home{
+                    Color.menuHomeOnPress.opacity(0.4)
+                } else if selection == .credit{
+                    Color.menuCreditOnPress.opacity(0.4)
+                } else{
+                    Color.menuOnPress
+                }
+            }
         }
     }
 }

--- a/RaniPaper/Source/View/MenuView/SideMenuView.swift
+++ b/RaniPaper/Source/View/MenuView/SideMenuView.swift
@@ -36,7 +36,6 @@ struct SideMenuView: View {
                                         selection = menu.viewSelection
                                     }
                                 }) {
-//                                    Image(menu.viewSelection.Name + (selection == menu.viewSelection ? "OnPress" : ""))
                                     Image(menu.viewSelection.Name + (selection == menu.viewSelection ? "OnPress" : ""))
                                         .resizable()
                                         .aspectRatio(contentMode: .fit)
@@ -45,7 +44,6 @@ struct SideMenuView: View {
                             }
                         }
                     }
-//                    TabButtonView(menu: viewModel.menuList[0])
 
                     Spacer()
                     


### PR DESCRIPTION
## 배경

- 사이드 메뉴로 화면 전환 시 메뉴 아이콘 잔상이 남아있는 현상이 있었습니다
- 특정 뷰에서 사이드 메뉴가 조금 열린 상태로 고정되는 현상이 있었습니다

## 작업 내용

- 사이드 메뉴 버튼 이미지 전환 시 0.1초의 딜레이를 주어 버튼이 전환된 뒤에 메뉴가 닫히도록 합니다
- ScrollView와 DragGesture를 함께 사용할 시 ScrollView 제스처에 의해 DragGesture이 취소되는 현상을 ViewModifier를 통해 구분하여 제스처를 적용합니다

## 추가 사항

- 제스처 충돌 해결 방법이 명확하지 않아 UX가 만족스럽지 못할 수 있어 피드백이 필요합니다