### PR TITLE
⚡ 메인 화면에 사이드 메뉴를 열 수 있는 버튼 추가

### DIFF
--- a/RaniPaper/Source/View/HomeView/HomeView.swift
+++ b/RaniPaper/Source/View/HomeView/HomeView.swift
@@ -32,6 +32,19 @@ struct HomeView: View {
                                             .onAppear { messageAnimation() }
                                     }
                                 }
+                            
+                            Button(action:{
+                                
+                            }){
+                                Image(systemName: "chevron.left")
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(width: ScreenSize.width * 0.045)
+                                    .foregroundColor(Color.black)
+                                    .shadow(color: .black, radius: 3, x: 1, y: 1)
+                                    .offset(x: ScreenSize.width * 0.4, y: -ScreenSize.height * 0.4)
+                            }
+                            
                             NavigationLink {
                                 MailBoxAnimationView(viewModel: viewModel)
                                     .navigationBarBackButtonHidden()

--- a/RaniPaper/Source/View/HomeView/HomeView.swift
+++ b/RaniPaper/Source/View/HomeView/HomeView.swift
@@ -33,18 +33,6 @@ struct HomeView: View {
                                     }
                                 }
                             
-                            Button(action:{
-                                
-                            }){
-                                Image(systemName: "chevron.left")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: ScreenSize.width * 0.045)
-                                    .foregroundColor(Color.black)
-                                    .shadow(color: .black, radius: 3, x: 1, y: 1)
-                                    .offset(x: ScreenSize.width * 0.4, y: -ScreenSize.height * 0.4)
-                            }
-                            
                             NavigationLink {
                                 MailBoxAnimationView(viewModel: viewModel)
                                     .navigationBarBackButtonHidden()

--- a/RaniPaper/Source/View/MenuView/MenuView.swift
+++ b/RaniPaper/Source/View/MenuView/MenuView.swift
@@ -16,6 +16,26 @@ struct MenuView: View {
     var body: some View {
         
         ZStack{
+            if userState.isMenuEnable{
+                Button(action:{
+                    if !viewModel.isOpen{
+                        viewModel.isOpen = true
+                        viewModel.Offset = Menu.maxOffset
+                    } else{
+                        
+                    }
+                }){
+                    Image(systemName: "chevron.left")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: ScreenSize.width * 0.045)
+                        .foregroundColor(Color.black)
+                        .shadow(color: .black, radius: 2, x: 1, y: 1)
+                        .padding(ScreenSize.width * 0.05)
+                }
+                .offset(x: ScreenSize.width * 0.4, y: -ScreenSize.height * 0.4)
+            }
+            
             Color.black
                 .opacity(viewModel.Offset == Menu.minOffset ? 0 : Double((ScreenSize.width-viewModel.Offset))/1300+0.05)
                 .animation(.easeIn, value: viewModel.Offset)

--- a/RaniPaper/Source/View/MenuView/MenuView.swift
+++ b/RaniPaper/Source/View/MenuView/MenuView.swift
@@ -16,7 +16,7 @@ struct MenuView: View {
     var body: some View {
         
         ZStack{
-            if userState.isMenuEnable{
+            if (userState.isMenuEnable) && (selection == .home){
                 Button(action:{
                     if !viewModel.isOpen{
                         viewModel.isOpen = true
@@ -25,12 +25,12 @@ struct MenuView: View {
                         
                     }
                 }){
-                    Image(systemName: "chevron.left")
+                    Image(systemName: "line.3.horizontal")
                         .resizable()
-                        .aspectRatio(contentMode: .fit)
-                        .frame(width: ScreenSize.width * 0.045)
+//                        .aspectRatio(contentMode: .fit)
+                        .frame(width: ScreenSize.width * 0.08, height: ScreenSize.height * 0.026)
                         .foregroundColor(Color.black)
-                        .shadow(color: .black, radius: 2, x: 1, y: 1)
+                        .shadow(color: .gray, radius: 3, y: 4)
                         .padding(ScreenSize.width * 0.05)
                 }
                 .offset(x: ScreenSize.width * 0.4, y: -ScreenSize.height * 0.4)


### PR DESCRIPTION
## 배경

- 사이드 메뉴를 슬라이드로 여닫는 것을 직관적으로 알기 힘들다는 피드백이 있었음

## 작업 내용

- SideMenuView 우측 상단에 버튼을 추가해 클릭 시 사이드 메뉴를 열도록 설정
- 해당 버튼을 홈 화면에서만 노출되게 함